### PR TITLE
Adding backup mainnet seeds to mainnet.txt

### DIFF
--- a/mainnet.txt
+++ b/mainnet.txt
@@ -4,9 +4,3 @@ cdcf936d70726dd724e0e6a8353d8e5ba5abdd20@seed2.mainnet.pokt.network:26663
 b3235089ff302c9615ba661e13e601d9d6265b15@seed4.mainnet.pokt.network:26663
 ab5776d1c9a50d47e30e90a0600e787d9fb74643@seed5.mainnet.pokt.network:26664
 a6dec84acfe1bae887cd6c4f2eeb864fae29c9f7@seed6.mainnet.pokt.network:26664
-
-Also you can use these seeds if the list above fails for any reason:
-7c0d7ec36db6594c1ffaa99724e1f8300bbd52d0@pocket-seed1.nodefleet.org:26662
-cdcf936d70726dd724e0e6a8353d8e5ba5abdd20@pocket-seed2.nodefleet.org:26663
-74b4322a91c4a7f3e774648d0730c1e610494691@pocket-seed3.nodefleet.org:26662
-b3235089ff302c9615ba661e13e601d9d6265b15@pocket-seed4.nodefleet.org:26663

--- a/mainnet.txt
+++ b/mainnet.txt
@@ -3,3 +3,8 @@ cdcf936d70726dd724e0e6a8353d8e5ba5abdd20@seed2.mainnet.pokt.network:26663
 74b4322a91c4a7f3e774648d0730c1e610494691@seed3.mainnet.pokt.network:26662
 b3235089ff302c9615ba661e13e601d9d6265b15@seed4.mainnet.pokt.network:26663
 
+Also you can use these seeds if the list above fails for any reason:
+7c0d7ec36db6594c1ffaa99724e1f8300bbd52d0@pocket-seed1.nodefleet.org:26662
+cdcf936d70726dd724e0e6a8353d8e5ba5abdd20@pocket-seed2.nodefleet.org:26663
+74b4322a91c4a7f3e774648d0730c1e610494691@pocket-seed3.nodefleet.org:26662
+b3235089ff302c9615ba661e13e601d9d6265b15@pocket-seed4.nodefleet.org:26663

--- a/mainnet.txt
+++ b/mainnet.txt
@@ -2,6 +2,8 @@
 cdcf936d70726dd724e0e6a8353d8e5ba5abdd20@seed2.mainnet.pokt.network:26663
 74b4322a91c4a7f3e774648d0730c1e610494691@seed3.mainnet.pokt.network:26662
 b3235089ff302c9615ba661e13e601d9d6265b15@seed4.mainnet.pokt.network:26663
+ab5776d1c9a50d47e30e90a0600e787d9fb74643@seed5.mainnet.pokt.network:26664
+a6dec84acfe1bae887cd6c4f2eeb864fae29c9f7@seed6.mainnet.pokt.network:26664
 
 Also you can use these seeds if the list above fails for any reason:
 7c0d7ec36db6594c1ffaa99724e1f8300bbd52d0@pocket-seed1.nodefleet.org:26662


### PR DESCRIPTION
These are some nodefleet's mainnet archival nodes that people can use as seeds in case default mainnet seeds list fails. 